### PR TITLE
Feature/statemachine

### DIFF
--- a/src/main/java/ai/statemachine/State.java
+++ b/src/main/java/ai/statemachine/State.java
@@ -2,6 +2,7 @@ package ai.statemachine;
 
 /**
  * <h1>Azurite</h1>
+ * Defines a state inside a {@link StateMachine} and can basically do anything inside its boundaries.
  *
  * @author Juyas
  * @version 13.07.2021
@@ -9,10 +10,22 @@ package ai.statemachine;
  */
 public interface State {
 
+    /**
+     * Called if the current state gets transitioned to.
+     */
     void enterState();
 
+    /**
+     * Update loop call from the object using the {@link StateMachine}
+     *
+     * @param dt the delta time value
+     */
     void updateState(float dt);
 
+    /**
+     * Called if the current state transitioned to another.
+     * Call happens before update loop call and before the next states {@link #enterState()}
+     */
     void exitState();
 
 }

--- a/src/main/java/ai/statemachine/State.java
+++ b/src/main/java/ai/statemachine/State.java
@@ -1,0 +1,18 @@
+package ai.statemachine;
+
+/**
+ * <h1>Azurite</h1>
+ *
+ * @author Juyas
+ * @version 13.07.2021
+ * @since 13.07.2021
+ */
+public interface State {
+
+    void enterState();
+
+    void updateState(float dt);
+
+    void exitState();
+
+}

--- a/src/main/java/ai/statemachine/StateMachine.java
+++ b/src/main/java/ai/statemachine/StateMachine.java
@@ -7,6 +7,10 @@ import java.util.function.Function;
 
 /**
  * <h1>Azurite</h1>
+ * A flexible implementation of a statemachine.
+ * This class can represent a deterministic or non-deterministic statemachine,
+ * however the actual transitions will never be random, therefore all statemachines are predictable in their transitions.
+ * It involves an unlimited number of states and transitions between them, which can be automated by adding conditions to them.
  *
  * @author Juyas
  * @version 13.07.2021
@@ -14,15 +18,24 @@ import java.util.function.Function;
  */
 public class StateMachine {
 
+    //contains all names mapped to their states
     private final HashMap<String, State> states;
+    //contains all state names mapped to their transitions
     private final HashMap<String, List<Transition>> transitions;
 
+    /**
+     * The name of the current state of the machine.
+     * Is null, if the machine is not started yet.
+     */
     private String currentState;
 
-    public StateMachine(String idleStateName, State idleState) {
+    /**
+     * Create a statemachine with no states or transitions.
+     */
+    public StateMachine() {
         this.states = new HashMap<>();
         this.transitions = new HashMap<>();
-        this.states.put(idleStateName, idleState);
+        this.currentState = null;
     }
 
     private void checkConditionalTransitions() {
@@ -35,20 +48,83 @@ public class StateMachine {
         }
     }
 
+    /**
+     * @see #currentState
+     */
     public String getCurrentStateName() {
         return currentState;
     }
 
+    /**
+     * @return the current {@link State} of the machine
+     */
     public State getCurrentState() {
         return states.get(currentState);
     }
 
+    /**
+     * Check if there is transition from a given state to a given state by their names.
+     *
+     * @param fromState the name of the state to start
+     * @param toState   the name of the state to potentially transition to
+     * @return true if and only if there is at least one know transition
+     */
     public boolean hasTransition(String fromState, String toState) {
         return this.transitions.containsKey(fromState)
                 && this.transitions.get(fromState).stream()
                 .anyMatch(transition -> transition.getToState().equals(toState));
     }
 
+    /**
+     * Check if there is any known state that can transition to the given state.
+     *
+     * @param state the name of the state to potentially transition to
+     * @return true if and only if there is any state that has a transition to the given one
+     */
+    public boolean canTransitionTo(String state) {
+        return transitions.values().stream().anyMatch(trans -> trans.stream().anyMatch(t -> t.getToState().equals(state)));
+    }
+
+    /**
+     * Check if there is any known transition outgoing from the given state.
+     *
+     * @param state the name of the state to transition from
+     * @return true if and only if there is any transition starting at the given state
+     */
+    public boolean hasTransition(String state) {
+        return transitions.containsKey(state);
+    }
+
+    /**
+     * Check if a state is known by its name.
+     *
+     * @param name the name of the state
+     * @return true if and only if there is a state by this name
+     */
+    public boolean hasState(String name) {
+        return states.containsKey(name);
+    }
+
+    /**
+     * Adds a new state to the machine.
+     *
+     * @param name  the name of the new state
+     * @param state the new state
+     * @return false if the state could not be added or a state with identical name already existed
+     */
+    public boolean addState(String name, State state) {
+        if (!hasState(name)) {
+            this.states.put(name, state);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Add a new transition.
+     *
+     * @see Transition#Transition(String, Function)
+     */
     public void addTransition(String fromState, String toState, Function<State, Boolean> condition) {
         Transition transition = new Transition(toState, condition);
         if (this.transitions.containsKey(fromState)) {
@@ -60,15 +136,63 @@ public class StateMachine {
         }
     }
 
+    /**
+     * Attempts to start the state machine.
+     * This is required to set the starting/current state of the machine and enable the update loop.
+     * The method {@link #doTransition(String)} will fail as well, before this method is called.
+     *
+     * @param startState the state to start from
+     * @return false, if the the statemachine could not be started, because
+     * - startState is null
+     * - startState is not known to the machine
+     * - currentState is already not null, so machine already started
+     */
+    public boolean startMachine(String startState) {
+        if (currentState == null && startState != null && states.containsKey(startState)) {
+            currentState = startState;
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Attempts to transition to the given state.
+     *
+     * @param toState the state to transition to
+     * @return false, if and only if the given stte is unknown or null
+     * @throws NullPointerException if the machine has not beeing started yet
+     */
     public boolean doTransition(String toState) {
-        if (!states.containsKey(toState)) return false;
+        if (toState == null || !states.containsKey(toState)) return false;
         getCurrentState().exitState();
         this.currentState = toState;
         getCurrentState().enterState();
         return true;
     }
 
+    /**
+     * Validate whether the state machine does not contain unreachable or deadlock states.
+     *
+     * @return false if and only if there are states, that do not transition or are orphaned
+     */
+    public boolean validate() {
+        //State should have a transition to elsewhere and should be transitionable to
+        for (String state : states.keySet()) {
+            if (!hasTransition(state) || !canTransitionTo(state))
+                return false;
+        }
+        return true;
+    }
+
+    /**
+     * Update loop method.
+     * Will do nothing, if the machine is not started.
+     *
+     * @param dt the delta time
+     * @see #startMachine(String)
+     */
     public void update(float dt) {
+        if (currentState == null) return;
         checkConditionalTransitions();
         getCurrentState().updateState(dt);
     }

--- a/src/main/java/ai/statemachine/StateMachine.java
+++ b/src/main/java/ai/statemachine/StateMachine.java
@@ -1,0 +1,76 @@
+package ai.statemachine;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * <h1>Azurite</h1>
+ *
+ * @author Juyas
+ * @version 13.07.2021
+ * @since 13.07.2021
+ */
+public class StateMachine {
+
+    private final HashMap<String, State> states;
+    private final HashMap<String, List<Transition>> transitions;
+
+    private String currentState;
+
+    public StateMachine(String idleStateName, State idleState) {
+        this.states = new HashMap<>();
+        this.transitions = new HashMap<>();
+        this.states.put(idleStateName, idleState);
+    }
+
+    private void checkConditionalTransitions() {
+        List<Transition> transitions = this.transitions.get(currentState);
+        for (Transition transition : transitions) {
+            if (transition.isConditionMet(getCurrentState())) {
+                if (doTransition(transition.getToState()))
+                    return;
+            }
+        }
+    }
+
+    public String getCurrentStateName() {
+        return currentState;
+    }
+
+    public State getCurrentState() {
+        return states.get(currentState);
+    }
+
+    public boolean hasTransition(String fromState, String toState) {
+        return this.transitions.containsKey(fromState)
+                && this.transitions.get(fromState).stream()
+                .anyMatch(transition -> transition.getToState().equals(toState));
+    }
+
+    public void addTransition(String fromState, String toState, Function<State, Boolean> condition) {
+        Transition transition = new Transition(toState, condition);
+        if (this.transitions.containsKey(fromState)) {
+            this.transitions.get(fromState).add(transition);
+        } else {
+            ArrayList<Transition> transitions = new ArrayList<>();
+            transitions.add(transition);
+            this.transitions.put(fromState, transitions);
+        }
+    }
+
+    public boolean doTransition(String toState) {
+        if (!states.containsKey(toState)) return false;
+        getCurrentState().exitState();
+        this.currentState = toState;
+        getCurrentState().enterState();
+        return true;
+    }
+
+    public void update(float dt) {
+        checkConditionalTransitions();
+        getCurrentState().updateState(dt);
+    }
+
+}

--- a/src/main/java/ai/statemachine/Transition.java
+++ b/src/main/java/ai/statemachine/Transition.java
@@ -1,0 +1,31 @@
+package ai.statemachine;
+
+import java.util.function.Function;
+
+/**
+ * <h1>Azurite</h1>
+ *
+ * @author Juyas
+ * @version 13.07.2021
+ * @since 13.07.2021
+ */
+public class Transition {
+
+    private final String toState;
+    private final Function<State, Boolean> condition;
+
+    public Transition(String toState, Function<State, Boolean> condition) {
+        this.toState = toState;
+        this.condition = condition;
+    }
+
+    public boolean isConditionMet(State currentState) {
+        return condition.apply(currentState);
+    }
+
+
+    public String getToState() {
+        return toState;
+    }
+
+}

--- a/src/main/java/ai/statemachine/Transition.java
+++ b/src/main/java/ai/statemachine/Transition.java
@@ -4,6 +4,7 @@ import java.util.function.Function;
 
 /**
  * <h1>Azurite</h1>
+ * Represents a transition inside a {@link StateMachine}.
  *
  * @author Juyas
  * @version 13.07.2021
@@ -11,19 +12,50 @@ import java.util.function.Function;
  */
 public class Transition {
 
+    /**
+     * The state to transition to, if the condition is met.
+     */
     private final String toState;
+    /**
+     * The method to check the condition.
+     * If the condition is met, the transition will be become active and the {@link StateMachine} transitions to
+     * {@link #toState}
+     */
     private final Function<State, Boolean> condition;
 
+    /**
+     * Create a full transition.
+     *
+     * @param toState   the state to transition to
+     * @param condition the condition to check
+     */
     public Transition(String toState, Function<State, Boolean> condition) {
         this.toState = toState;
         this.condition = condition;
     }
 
+    /**
+     * Create a transition, that never automatically activates, since the condition will never be met.
+     *
+     * @param toState the state to transition to
+     */
+    public Transition(String toState) {
+        this(toState, x -> false);
+    }
+
+    /**
+     * Check if the condition is met for the given state.
+     *
+     * @param currentState the current state to check if it can transition this way
+     * @return true if and only if the condition is met and the current state can transition to {@link #toState}
+     */
     public boolean isConditionMet(State currentState) {
         return condition.apply(currentState);
     }
 
-
+    /**
+     * @see #toState
+     */
     public String getToState() {
         return toState;
     }


### PR DESCRIPTION
Add a statemachine for ai behaviour or any kind of use.

- Supports manual and automated state transitions based on external conditions.
- States are reduced to enter/exit and update method to keep it clean and will be linked with a name to a state machine
- Statemachine can check for deadlocking states and unreachable states (if wished and only useful for automated transitions)